### PR TITLE
Fix Rust build, incl. scanner.c

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "tree-sitter-ROC"
+name = "tree-sitter-roc"
 description = "ROC grammar for the tree-sitter parsing library"
 version = "0.0.1"
 keywords = ["incremental", "parsing", "ROC"]
 categories = ["parsing", "text-editors"]
-repository = "https://github.com/tree-sitter/tree-sitter-ROC"
+repository = "https://github.com/faldor20/tree-sitter-roc"
 edition = "2018"
 license = "MIT"
 

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_ROC::language()).expect("Error loading ROC grammar");
+//! parser.set_language(tree_sitter_roc::language()).expect("Error loading ROC grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -18,14 +18,14 @@
 use tree_sitter::Language;
 
 extern "C" {
-    fn tree_sitter_ROC() -> Language;
+    fn tree_sitter_roc() -> Language;
 }
 
 /// Get the tree-sitter [Language][] for this grammar.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 pub fn language() -> Language {
-    unsafe { tree_sitter_ROC() }
+    unsafe { tree_sitter_roc() }
 }
 
 /// The content of the [`node-types.json`][] file for this grammar.

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -172,9 +172,11 @@ bool tree_sitter_roc_external_scanner_scan(void *payload, TSLexer *lexer,
 
   bool error_recovery_mode =
       valid_symbols[STRING_CONTENT] && valid_symbols[INDENT];
-  bool within_brackets = valid_symbols[CLOSE_BRACE] ||
-                         valid_symbols[CLOSE_PAREN] ||
-                         valid_symbols[CLOSE_BRACKET];
+  
+  // FIXME unused
+  // bool within_brackets = valid_symbols[CLOSE_BRACE] ||
+  //                       valid_symbols[CLOSE_PAREN] ||
+  //                       valid_symbols[CLOSE_BRACKET];
 
   bool advanced_once = false;
   if (valid_symbols[ESCAPE_INTERPOLATION] && scanner->delimiters.len > 0 &&
@@ -480,7 +482,7 @@ unsigned tree_sitter_roc_external_scanner_serialize(void *payload,
   }
   size += delimiter_count;
 
-  int iter = 1;
+  unsigned int iter = 1;
   for (; iter < scanner->indents.len &&
          size < TREE_SITTER_SERIALIZATION_BUFFER_SIZE;
        ++iter) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -172,11 +172,6 @@ bool tree_sitter_roc_external_scanner_scan(void *payload, TSLexer *lexer,
 
   bool error_recovery_mode =
       valid_symbols[STRING_CONTENT] && valid_symbols[INDENT];
-  
-  // FIXME unused
-  // bool within_brackets = valid_symbols[CLOSE_BRACE] ||
-  //                       valid_symbols[CLOSE_PAREN] ||
-  //                       valid_symbols[CLOSE_BRACKET];
 
   bool advanced_once = false;
   if (valid_symbols[ESCAPE_INTERPOLATION] && scanner->delimiters.len > 0 &&


### PR DESCRIPTION
The tree sitter were not working when using from rust, esp. in build.rs a code block needed to be uncommented. Further more I fixed same small compiler warnings and changed the package name to be lower case (ROC -> roc), to be more aligned with other tree sitter packages. See https://github.com/zed-industries/zed/blob/main/Cargo.toml.
Background: I'm in the middle to integrate the tree sitter and language server into Zed. 