### PR TITLE
language server binary name changed again

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Reference it from your editor somehow.
 My full config for roc is below: 
 ```toml
 [language-server.roc-ls]
-command = "roc_lang_server"
+command = "roc_language_server"
 
 [[language]]
 name = "roc"


### PR DESCRIPTION
https://github.com/roc-lang/roc/pull/6352 changed the name of the language server. I've verified that it did change the binary in the latest nightly build. 