### PR TITLE
Support for arguments in record builder

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -313,7 +313,7 @@ module.exports = grammar({
 		record_field_expr: ($) =>
 			prec.right(seq($.field_name, optional(seq(":", $.expr_body)))),
 		record_field_builder: ($) =>
-			seq($.field_name, seq(":", "<-", $.identifier)),
+			seq($.field_name, seq(":", "<-", choice($.function_call_expr, $._function_call_target))),
 
 		record_expr: ($) =>
 			seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1098,8 +1098,17 @@
               "value": "<-"
             },
             {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "function_call_expr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_function_call_target"
+                }
+              ]
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2906,11 +2906,27 @@
       "required": true,
       "types": [
         {
+          "type": "field_access_expr",
+          "named": true
+        },
+        {
           "type": "field_name",
           "named": true
         },
         {
-          "type": "identifier",
+          "type": "function_call_expr",
+          "named": true
+        },
+        {
+          "type": "operator_as_function_expr",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expr",
+          "named": true
+        },
+        {
+          "type": "variable_expr",
           "named": true
         }
       ]

--- a/test/corpus/basic.txt
+++ b/test/corpus/basic.txt
@@ -35,13 +35,16 @@ main=
               (record_expr
                 (record_field_builder
                   (field_name)
-                  (identifier))
+                  (variable_expr
+                        (identifier)))
                 (record_field_builder
                   (field_name)
-                  (identifier))
+                  (variable_expr
+                        (identifier)))
                 (record_field_builder
                   (field_name)
-                  (identifier))))
+                  (variable_expr
+                        (identifier)))))
             (operator)
             (variable_expr
               (identifier)))))

--- a/test/corpus/record.txt
+++ b/test/corpus/record.txt
@@ -192,15 +192,97 @@ main=
               (record_expr
                 (record_field_builder
                   (field_name)
-                  (identifier))
+                  (variable_expr
+                        (identifier)))
                 (record_field_builder
                   (field_name)
-                  (identifier))
+                  (variable_expr
+                        (identifier)))
                 (record_field_builder
                   (field_name)
-                  (identifier))))
+                  (variable_expr
+                        (identifier)))))
             (operator)
             (variable_expr
               (identifier)))))
       (variable_expr
         (identifier)))))
+
+================================================================================
+record builder w/args
+================================================================================
+
+main=
+  cliBuilder {
+    alpha: <- numOption { name: Short "a", help: "Set alpha level." },
+    beta: <- flagOption { name: Both "b" "beta" },
+  }
+  |> finishCli { name: "app", version: "v0.0.1", authors: ["foobar foo@bar.baz"] }
+
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (bin_op_expr
+        (function_call_expr
+          (variable_expr
+            (identifier))
+          (record_expr
+            (record_field_builder
+              (field_name)
+              (function_call_expr
+                (variable_expr
+                  (identifier))
+                (record_expr
+                  (record_field_expr
+                    (field_name)
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (const
+                          (string)))))
+                  (record_field_expr
+                    (field_name)
+                    (expr_body
+                      (const
+                        (string)))))))
+            (record_field_builder
+              (field_name)
+              (function_call_expr
+                (variable_expr
+                  (identifier))
+                (record_expr
+                  (record_field_expr
+                    (field_name)
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (const
+                          (string))
+                        (const
+                          (string))))))))))
+        (operator)
+        (function_call_expr
+          (variable_expr
+            (identifier))
+          (record_expr
+            (record_field_expr
+              (field_name)
+              (expr_body
+                (const
+                  (string))))
+            (record_field_expr
+              (field_name)
+              (expr_body
+                (const
+                  (string))))
+            (record_field_expr
+              (field_name)
+              (expr_body
+                (list_expr
+                  (const
+                    (string)))))))))))


### PR DESCRIPTION
While playing around with [smores56/weaver](https://github.com/smores56/weaver) I noticed that the record builder pattern in tree-sitter assumes no arguments. This is the fix I'm using locally but feel free to drop the PR treat this as a bug report if it's not correct.