### PR TITLE
Support new lambda syntax

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_roc_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-roc"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_roc "github.com/tree-sitter/tree-sitter-roc/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter/tree-sitter-roc
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("can load grammar", () => {
+  const parser = new (require("tree-sitter"))();
+  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+});

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_roc
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_roc.language())
+        except Exception:
+            self.fail("Error loading Roc grammar")

--- a/bindings/python/tree_sitter_roc/binding.c
+++ b/bindings/python/tree_sitter_roc/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_roc(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_roc());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_roc(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -7,6 +7,9 @@ fn main() {
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs");
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,44 +1,45 @@
-//! This crate provides ROC language support for the [tree-sitter][] parsing library.
+//! This crate provides Roc language support for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
+//! Typically, you will use the [LANGUAGE][] constant to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_roc::language()).expect("Error loading ROC grammar");
+//! let language = tree_sitter_roc::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Roc parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_roc() -> Language;
+    fn tree_sitter_roc() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// The tree-sitter [`LanguageFn`][LanguageFn] for this grammar.
 ///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_roc() }
-}
+/// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_roc) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-// Uncomment these to include any queries that this grammar contains
+// NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +47,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
-            .expect("Error loading ROC language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Roc parser");
     }
 }

--- a/bindings/swift/TreeSitterRocTests/TreeSitterRocTests.swift
+++ b/bindings/swift/TreeSitterRocTests/TreeSitterRocTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterRoc
+
+final class TreeSitterRocTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_roc())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading Roc grammar")
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-roc
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/grammar.js
+++ b/grammar.js
@@ -302,13 +302,24 @@ module.exports = grammar({
 			),
 		anon_fun_expr: ($) =>
 			prec.left(
-				seq(
-					$.backslash,
-					$.argument_patterns,
-					$.arrow,
-					$.expr_body,
-					optional($._newline),
-				),
+        choice(
+          // new syntax
+          seq(
+            $.lambda_delimiter,
+            $.argument_patterns,
+            $.lambda_delimiter,
+            $.expr_body,
+            optional($._newline),
+          ),
+          // old syntax
+          seq(
+            $.backslash,
+            $.argument_patterns,
+            $.arrow,
+            $.expr_body,
+            optional($._newline),
+          ),
+        ),
 			),
 
 		//RECORDS
@@ -830,6 +841,7 @@ module.exports = grammar({
 		opaque_tag: ($) => /@[A-Z][0-9a-zA-Z_]*/,
 		module: ($) => alias($._upper_identifier, $.module),
 		backslash: ($) => "\\",
+    lambda_delimiter: ($) => "|",
 
 		doc_comment: ($) => token(prec(-1, /##[^\n]*/)),
 		line_comment: ($) => token(prec(-1, /#[^\n]*/)),

--- a/neovim/queries/highlights.scm
+++ b/neovim/queries/highlights.scm
@@ -60,6 +60,7 @@
   "}"
   "["
   "]"
+  (lambda_delimiter)
 ] @punctuation.bracket
 
 [

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -66,6 +66,7 @@
   "["
   "]"
   (interpolation_char)
+  (lambda_delimiter)
 ] @punctuation.bracket
 
 [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1020,33 +1020,71 @@
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "backslash"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "argument_patterns"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "arrow"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "expr_body"
-          },
-          {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_newline"
+                "name": "lambda_delimiter"
               },
               {
-                "type": "BLANK"
+                "type": "SYMBOL",
+                "name": "argument_patterns"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "lambda_delimiter"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expr_body"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_newline"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "backslash"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "argument_patterns"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "arrow"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expr_body"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_newline"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               }
             ]
           }
@@ -4434,6 +4472,10 @@
     "backslash": {
       "type": "STRING",
       "value": "\\"
+    },
+    "lambda_delimiter": {
+      "type": "STRING",
+      "value": "|"
     },
     "doc_comment": {
       "type": "TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -200,6 +200,10 @@
         {
           "type": "expr_body",
           "named": true
+        },
+        {
+          "type": "lambda_delimiter",
+          "named": true
         }
       ]
     }
@@ -2202,6 +2206,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "lambda_delimiter",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "list_expr",
@@ -4413,11 +4422,11 @@
   },
   {
     "type": "as",
-    "named": false
+    "named": true
   },
   {
     "type": "as",
-    "named": true
+    "named": false
   },
   {
     "type": "backslash",
@@ -4513,11 +4522,11 @@
   },
   {
     "type": "module",
-    "named": true
+    "named": false
   },
   {
     "type": "module",
-    "named": false
+    "named": true
   },
   {
     "type": "natural",

--- a/test/corpus/complex_updated_syntax.txt
+++ b/test/corpus/complex_updated_syntax.txt
@@ -1,0 +1,2093 @@
+================================================================================
+complex_file
+================================================================================
+app [main] { pf: platform "cli-platform/main.roc" }
+
+import pf.Stdin
+import pf.Stdout
+import pf.Task exposing [await, loop, succeed]
+import "./file.txt" as file : Str
+
+main =
+    _ <- await (Stdout.line "\nLet's count down from 10 together - all you have to do is press <ENTER>.")
+    _ <- await Stdin.line
+    loop 10 tick
+
+tick = |n|
+    if n == 0 then
+        _ <- await (Stdout.line "SURPRISE! Happy Birthday! ")
+        succeed (Done {})
+    else
+        _ <- await (n |> Num.toStr |> |s | "$(s)..." |> Stdout.line)
+        _ <- await Stdin.line
+        succeed (Step (n - 1))
+
+--------------------------------------------------------------------------------
+
+(file
+  (app_header
+    (provides_list
+      (ident))
+    (packages_list
+      (platform_ref
+        (identifier)
+        (package_uri))))
+  (import_expr
+    (identifier)
+    (module))
+  (import_expr
+    (identifier)
+    (module))
+  (import_expr
+    (identifier)
+    (module)
+    (exposing)
+    (exposing
+      (ident)
+      (ident)
+      (ident)))
+  (import_file_expr
+    (string)
+    (identifier)
+    (concrete_type))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (backpassing_expr
+        (wildcard_pattern)
+        (back_arrow)
+        (function_call_expr
+          (variable_expr
+            (identifier))
+          (parenthesized_expr
+            (expr_body
+              (function_call_expr
+                (variable_expr
+                  (module)
+                  (identifier))
+                (const
+                  (string
+                    (escape_char))))))))
+      (backpassing_expr
+        (wildcard_pattern)
+        (back_arrow)
+        (function_call_expr
+          (variable_expr
+            (identifier))
+          (variable_expr
+            (module)
+            (identifier))))
+      (function_call_expr
+        (variable_expr
+          (identifier))
+        (const
+          (int))
+        (variable_expr
+          (identifier)))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (if_expr
+            (bin_op_expr
+              (variable_expr
+                (identifier))
+              (operator)
+              (const
+                (int)))
+            (then
+              (expr_body
+                (backpassing_expr
+                  (wildcard_pattern)
+                  (back_arrow)
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (parenthesized_expr
+                      (expr_body
+                        (function_call_expr
+                          (variable_expr
+                            (module)
+                            (identifier))
+                          (const
+                            (string)))))))
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (record_expr)))))))
+            (else
+              (expr_body
+                (backpassing_expr
+                  (wildcard_pattern)
+                  (back_arrow)
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (parenthesized_expr
+                      (expr_body
+                        (bin_op_expr
+                          (variable_expr
+                            (identifier))
+                          (operator)
+                          (variable_expr
+                            (module)
+                            (identifier))
+                          (operator)
+                          (anon_fun_expr
+                            (lambda_delimiter)
+                            (argument_patterns
+                              (identifier_pattern
+                                (identifier)))
+                            (lambda_delimiter)
+                            (expr_body
+                              (bin_op_expr
+                                (const
+                                  (string
+                                    (interpolation_char
+                                      (variable_expr
+                                        (identifier)))))
+                                (operator)
+                                (variable_expr
+                                  (module)
+                                  (identifier))))))))))
+                (backpassing_expr
+                  (wildcard_pattern)
+                  (back_arrow)
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (variable_expr
+                      (module)
+                      (identifier))))
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (parenthesized_expr
+                          (expr_body
+                            (bin_op_expr
+                              (variable_expr
+                                (identifier))
+                              (operator)
+                              (const
+                                (int)))))))))))))))))
+
+================================================================================
+simple_env
+================================================================================
+
+main =
+  task =
+    a "E"
+    |> t (|a | e "")
+    |> t (|{} | Env.decode "SHLVL")
+  task
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (value_declaration
+        (decl_left
+          (identifier_pattern
+            (identifier)))
+        (expr_body
+          (bin_op_expr
+            (function_call_expr
+              (variable_expr
+                (identifier))
+              (const
+                (string)))
+            (operator)
+            (function_call_expr
+              (variable_expr
+                (identifier))
+              (parenthesized_expr
+                (expr_body
+                  (anon_fun_expr
+                    (lambda_delimiter)
+                    (argument_patterns
+                      (identifier_pattern
+                        (identifier)))
+                    (lambda_delimiter)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (const
+                          (string))))))))
+            (operator)
+            (function_call_expr
+              (variable_expr
+                (identifier))
+              (parenthesized_expr
+                (expr_body
+                  (anon_fun_expr
+                    (lambda_delimiter)
+                    (argument_patterns
+                      (record_pattern))
+                    (lambda_delimiter)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (const
+                          (string)))))))))))
+      (variable_expr
+        (identifier)))))
+
+================================================================================
+complex_env_decode
+================================================================================
+
+app [main] { pf: platform "cli-platform/main.roc" }
+
+import pf.Stdout
+import pf.Stderr
+import pf.Env
+import pf.Task exposing [Task]
+
+main : Task {} []
+main =
+    task =
+      x
+      |> Task.await (|editor | Stdout.line "Your favorite editor is \(editor)!")
+      |> Task.await (|{} | Env.decode "SHLVL")
+      |> Task.await
+          (|lvl |
+              when lvl is
+                  1 -> Stdout.line "You're running this in a root shell!"
+                  n ->
+                      lvlStr = Num.toStr n
+
+                      Stdout.line "Your current shell level is \(lvlStr)!")
+      |> Task.await "LETTERS"
+  a
+--------------------------------------------------------------------------------
+
+(file
+  (app_header
+    (provides_list
+      (ident))
+    (packages_list
+      (platform_ref
+        (identifier)
+        (package_uri))))
+  (import_expr
+    (identifier)
+    (module))
+  (import_expr
+    (identifier)
+    (module))
+  (import_expr
+    (identifier)
+    (module))
+  (import_expr
+    (identifier)
+    (module)
+    (exposing)
+    (exposing
+      (ident)))
+  (value_declaration
+    (annotation_type_def
+      (annotation_pre_colon
+        (identifier))
+      (apply_type
+        (concrete_type)
+        (apply_type_args
+          (apply_type_arg
+            (record_type))
+          (apply_type_arg
+            (tags_type)))))
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (value_declaration
+        (decl_left
+          (identifier_pattern
+            (identifier)))
+        (expr_body
+          (bin_op_expr
+            (variable_expr
+              (identifier))
+            (operator)
+            (function_call_expr
+              (variable_expr
+                (module)
+                (identifier))
+              (parenthesized_expr
+                (expr_body
+                  (anon_fun_expr
+                    (lambda_delimiter)
+                    (argument_patterns
+                      (identifier_pattern
+                        (identifier)))
+                    (lambda_delimiter)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (const
+                          (string
+                            (interpolation_char
+                              (variable_expr
+                                (identifier)))))))))))
+            (operator)
+            (function_call_expr
+              (variable_expr
+                (module)
+                (identifier))
+              (parenthesized_expr
+                (expr_body
+                  (anon_fun_expr
+                    (lambda_delimiter)
+                    (argument_patterns
+                      (record_pattern))
+                    (lambda_delimiter)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (const
+                          (string))))))))
+            (operator)
+            (function_call_expr
+              (variable_expr
+                (module)
+                (identifier))
+              (parenthesized_expr
+                (expr_body
+                  (anon_fun_expr
+                    (lambda_delimiter)
+                    (argument_patterns
+                      (identifier_pattern
+                        (identifier)))
+                    (lambda_delimiter)
+                    (expr_body
+                      (when_is_expr
+                        (when)
+                        (variable_expr
+                          (identifier))
+                        (is)
+                        (when_is_branch
+                          (const_pattern
+                            (int))
+                          (arrow)
+                          (expr_body
+                            (function_call_expr
+                              (variable_expr
+                                (module)
+                                (identifier))
+                              (const
+                                (string)))))
+                        (when_is_branch
+                          (identifier_pattern
+                            (identifier))
+                          (arrow)
+                          (expr_body
+                            (value_declaration
+                              (decl_left
+                                (identifier_pattern
+                                  (identifier)))
+                              (expr_body
+                                (function_call_expr
+                                  (variable_expr
+                                    (module)
+                                    (identifier))
+                                  (variable_expr
+                                    (identifier)))))
+                            (function_call_expr
+                              (variable_expr
+                                (module)
+                                (identifier))
+                              (const
+                                (string
+                                  (interpolation_char
+                                    (variable_expr
+                                      (identifier))))))))))))))
+            (operator)
+            (function_call_expr
+              (variable_expr
+                (module)
+                (identifier))
+              (const
+                (string))))))
+      (variable_expr
+        (identifier)))))
+
+================================================================================
+complex_interface
+================================================================================
+
+module [ReadErr, DeleteErr, DirEntry, deleteEmptyDir, deleteRecursive, list]
+
+import Effect
+import Task exposing [Task]
+import InternalTask
+import Path exposing [Path]
+import InternalPath
+import InternalDir
+
+ReadErr : InternalDir.ReadErr
+
+DeleteErr : InternalDir.DeleteErr
+
+DirEntry : InternalDir.DirEntry
+
+list : Path -> Task (List Path) [DirReadErr Path ReadErr]
+list = |path |
+    effect = Effect.map (Effect.dirList (InternalPath.toBytes path)) |result |
+        when result is
+            Ok entries -> Ok (List.map entries InternalPath.fromOsBytes)
+            Err err -> Err (DirReadErr path err)
+
+    InternalTask.fromEffect effect
+
+deleteEmptyDir : Path -> Task
+deleteRecursive : Path -> Task
+--------------------------------------------------------------------------------
+
+(file
+  (module_header
+    (exposes_list
+      (ident)
+      (ident)
+      (ident)
+      (ident)
+      (ident)
+      (ident)))
+  (import_expr
+    (module))
+  (import_expr
+    (module)
+    (exposing)
+    (exposing
+      (ident)))
+  (import_expr
+    (module))
+  (import_expr
+    (module)
+    (exposing)
+    (exposing
+      (ident)))
+  (import_expr
+    (module))
+  (import_expr
+    (module))
+  (alias_type_def
+    (apply_type
+      (concrete_type))
+    (apply_type
+      (concrete_type)))
+  (alias_type_def
+    (apply_type
+      (concrete_type))
+    (apply_type
+      (concrete_type)))
+  (alias_type_def
+    (apply_type
+      (concrete_type))
+    (apply_type
+      (concrete_type)))
+  (value_declaration
+    (annotation_type_def
+      (annotation_pre_colon
+        (identifier))
+      (function_type
+        (apply_type
+          (concrete_type))
+        (arrow)
+        (apply_type
+          (concrete_type)
+          (apply_type_args
+            (apply_type_arg
+              (parenthesized_type
+                (apply_type
+                  (concrete_type)
+                  (apply_type_args
+                    (apply_type_arg
+                      (apply_type
+                        (concrete_type)))))))
+            (apply_type_arg
+              (tags_type
+                (apply_type
+                  (concrete_type)
+                  (apply_type_args
+                    (apply_type_arg
+                      (apply_type
+                        (concrete_type)
+                        (apply_type_args
+                          (apply_type_arg
+                            (apply_type
+                              (concrete_type))))))))))))))
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (value_declaration
+            (decl_left
+              (identifier_pattern
+                (identifier)))
+            (expr_body
+              (function_call_expr
+                (variable_expr
+                  (module)
+                  (identifier))
+                (parenthesized_expr
+                  (expr_body
+                    (function_call_expr
+                      (variable_expr
+                        (module)
+                        (identifier))
+                      (parenthesized_expr
+                        (expr_body
+                          (function_call_expr
+                            (variable_expr
+                              (module)
+                              (identifier))
+                            (variable_expr
+                              (identifier))))))))
+                (anon_fun_expr
+                  (lambda_delimiter)
+                  (argument_patterns
+                    (identifier_pattern
+                      (identifier)))
+                  (lambda_delimiter)
+                  (expr_body
+                    (when_is_expr
+                      (when)
+                      (variable_expr
+                        (identifier))
+                      (is)
+                      (when_is_branch
+                        (tag_pattern
+                          (tag)
+                          (identifier_pattern
+                            (identifier)))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (parenthesized_expr
+                              (expr_body
+                                (function_call_expr
+                                  (variable_expr
+                                    (module)
+                                    (identifier))
+                                  (variable_expr
+                                    (identifier))
+                                  (variable_expr
+                                    (module)
+                                    (identifier))))))))
+                      (when_is_branch
+                        (tag_pattern
+                          (tag)
+                          (identifier_pattern
+                            (identifier)))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (parenthesized_expr
+                              (expr_body
+                                (tag_expr
+                                  (tag)
+                                  (variable_expr
+                                    (identifier))
+                                  (variable_expr
+                                    (identifier))))))))))))))
+          (function_call_expr
+            (variable_expr
+              (module)
+              (identifier))
+            (variable_expr
+              (identifier)))))))
+  (annotation_type_def
+    (annotation_pre_colon
+      (identifier))
+    (function_type
+      (apply_type
+        (concrete_type))
+      (arrow)
+      (apply_type
+        (concrete_type))))
+  (annotation_type_def
+    (annotation_pre_colon
+      (identifier))
+    (function_type
+      (apply_type
+        (concrete_type))
+      (arrow)
+      (apply_type
+        (concrete_type)))))
+
+================================================================================
+complex_list
+================================================================================
+view : NavLink, Str -> Html.Node
+view = |currentNavLink, htmlContent |
+    html [lang "en"] [
+        head [] [
+            meta [httpEquiv "content-type", content "text/html; charset=utf-8"],
+            Html.title [] [text currentNavLink.title],
+            link [rel "stylesheet", href "style.css"],
+        ],
+        body [] [
+            div [class "main"] [
+                div [class "navbar"] [
+                    viewNavbar currentNavLink,
+                ],
+                div [class "article"] [
+                    text htmlContent,
+                ],
+            ],
+        ],
+    ]
+
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (annotation_type_def
+      (annotation_pre_colon
+        (identifier))
+      (function_type
+        (apply_type
+          (concrete_type))
+        (apply_type
+          (concrete_type))
+        (arrow)
+        (apply_type
+          (concrete_type))))
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (function_call_expr
+            (variable_expr
+              (identifier))
+            (list_expr
+              (function_call_expr
+                (variable_expr
+                  (identifier))
+                (const
+                  (string))))
+            (list_expr
+              (function_call_expr
+                (variable_expr
+                  (identifier))
+                (list_expr)
+                (list_expr
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (list_expr
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (const
+                          (string)))
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (const
+                          (string)))))
+                  (function_call_expr
+                    (variable_expr
+                      (module)
+                      (identifier))
+                    (list_expr)
+                    (list_expr
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (field_access_expr
+                          (variable_expr
+                            (identifier))
+                          (identifier)))))
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (list_expr
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (const
+                          (string)))
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (const
+                          (string)))))))
+              (function_call_expr
+                (variable_expr
+                  (identifier))
+                (list_expr)
+                (list_expr
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (list_expr
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (const
+                          (string))))
+                    (list_expr
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (list_expr
+                          (function_call_expr
+                            (variable_expr
+                              (identifier))
+                            (const
+                              (string))))
+                        (list_expr
+                          (function_call_expr
+                            (variable_expr
+                              (identifier))
+                            (variable_expr
+                              (identifier)))))
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (list_expr
+                          (function_call_expr
+                            (variable_expr
+                              (identifier))
+                            (const
+                              (string))))
+                        (list_expr
+                          (function_call_expr
+                            (variable_expr
+                              (identifier))
+                            (variable_expr
+                              (identifier))))))))))))))))
+
+================================================================================
+complex_if_else
+================================================================================
+viewNavLink = |isCurrent, navlink |
+    if isCurrent then
+        li [class "nav-link nav-link--current"] [
+            text navlink.text,
+        ]
+    else
+        li [class "nav-link"] [
+            a
+                [href navlink.url, title navlink.title]
+                [text navlink.text],
+        ]
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (if_expr
+            (variable_expr
+              (identifier))
+            (then
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (list_expr
+                    (function_call_expr
+                      (variable_expr
+                        (identifier))
+                      (const
+                        (string))))
+                  (list_expr
+                    (function_call_expr
+                      (variable_expr
+                        (identifier))
+                      (field_access_expr
+                        (variable_expr
+                          (identifier))
+                        (identifier)))))))
+            (else
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (list_expr
+                    (function_call_expr
+                      (variable_expr
+                        (identifier))
+                      (const
+                        (string))))
+                  (list_expr
+                    (function_call_expr
+                      (variable_expr
+                        (identifier))
+                      (list_expr
+                        (function_call_expr
+                          (variable_expr
+                            (identifier))
+                          (field_access_expr
+                            (variable_expr
+                              (identifier))
+                            (identifier)))
+                        (function_call_expr
+                          (variable_expr
+                            (identifier))
+                          (field_access_expr
+                            (variable_expr
+                              (identifier))
+                            (identifier))))
+                      (list_expr
+                        (function_call_expr
+                          (variable_expr
+                            (identifier))
+                          (field_access_expr
+                            (variable_expr
+                              (identifier))
+                            (identifier)))))))))))))))
+
+================================================================================
+if func
+================================================================================
+viewNavLink = |isCurrent, navlink |
+    if isCurrent then
+      a b
+    else
+      a p
+
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (if_expr
+            (variable_expr
+              (identifier))
+            (then
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (variable_expr
+                    (identifier)))))
+            (else
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (variable_expr
+                    (identifier)))))))))))
+
+================================================================================
+annotation_run_on
+================================================================================
+expect
+  iput : List F64
+  iput = [-1, 0.00001, 1e12, 2.0e-2, 0.0003, 43]
+  actual = Encode.toBytes input json
+  expected = Str.toUtf8 "[-1,0.00001,1000000000000,0.02,0.0003,43]"
+
+  actual == expected
+--------------------------------------------------------------------------------
+
+(file
+  (expect
+    (expr_body
+      (value_declaration
+        (annotation_type_def
+          (annotation_pre_colon
+            (identifier))
+          (apply_type
+            (concrete_type)
+            (apply_type_args
+              (apply_type_arg
+                (apply_type
+                  (concrete_type))))))
+        (decl_left
+          (identifier_pattern
+            (identifier)))
+        (expr_body
+          (list_expr
+            (prefixed_expression
+              (operator)
+              (const
+                (int)))
+            (const
+              (float))
+            (const
+              (float))
+            (const
+              (float))
+            (const
+              (float))
+            (const
+              (int)))))
+      (value_declaration
+        (decl_left
+          (identifier_pattern
+            (identifier)))
+        (expr_body
+          (function_call_expr
+            (variable_expr
+              (module)
+              (identifier))
+            (variable_expr
+              (identifier))
+            (variable_expr
+              (identifier)))))
+      (value_declaration
+        (decl_left
+          (identifier_pattern
+            (identifier)))
+        (expr_body
+          (function_call_expr
+            (variable_expr
+              (module)
+              (identifier))
+            (const
+              (string)))))
+      (bin_op_expr
+        (variable_expr
+          (identifier))
+        (operator)
+        (variable_expr
+          (identifier))))))
+
+================================================================================
+tags_mistake_field
+================================================================================
+encodeStrBytes = |str |
+    bytes = Str.toUtf8 str
+    p=bytes a
+
+    initialState = { bytePos: 0, status: NoEscapesFound }
+
+    firstPassState =
+        List.walkUntil bytes initialState |{ bytePos, status }, b |
+            when b is
+                0x22 -> Break { bytePos, status: FoundEscape } # U+0022 Quotation mark
+                0x5c -> Break { bytePos, status: FoundEscape } # U+005c Reverse solidus
+                0x2f -> Break { bytePos, status: FoundEscape } # U+002f Solidus
+                0x08 -> Break { bytePos, status: FoundEscape } # U+0008 Backspace
+                0x0c -> Break { bytePos, status: FoundEscape } # U+000c Form feed
+                0x0a -> Break { bytePos, status: FoundEscape } # U+000a Line feed
+                0x0d -> Break { bytePos, status: FoundEscape } # U+000d Carriage return
+                0x09 -> Break { bytePos, status: FoundEscape } # U+0009 Tab
+                _ -> Continue { bytePos: bytePos + 1, status }
+
+    when firstPassState.status is
+        NoEscapesFound ->
+            (List.len bytes)
+            + 2
+            |> List.withCapacity
+            |> List.concat ['"']
+            |> List.concat bytes
+            |> List.concat ['"']
+
+        FoundEscape ->
+            { before: bytesBeforeEscape, others: bytesWithEscapes } =
+                List.split bytes firstPassState.bytePos
+
+            # Reserve List with 120% capacity for escaped bytes to reduce
+            # allocations, include starting quote, and bytes up to first escape
+            initial =
+                List.len bytes
+                |> Num.mul 120
+                |> Num.divCeil 100
+                |> List.withCapacity
+                |> List.concat ['"']
+                |> List.concat bytesBeforeEscape
+
+            # Walk the remaining bytes and include escape '\' as required
+            # add closing quote
+            List.walk bytesWithEscapes initial |encodedBytes, byte |
+                List.concat encodedBytes (escapedByteToJson byte)
+            |> List.concat ['"']
+
+
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (value_declaration
+            (decl_left
+              (identifier_pattern
+                (identifier)))
+            (expr_body
+              (function_call_expr
+                (variable_expr
+                  (module)
+                  (identifier))
+                (variable_expr
+                  (identifier)))))
+          (value_declaration
+            (decl_left
+              (identifier_pattern
+                (identifier)))
+            (expr_body
+              (function_call_expr
+                (variable_expr
+                  (identifier))
+                (variable_expr
+                  (identifier)))))
+          (value_declaration
+            (decl_left
+              (identifier_pattern
+                (identifier)))
+            (expr_body
+              (record_expr
+                (record_field_expr
+                  (field_name)
+                  (expr_body
+                    (const
+                      (int))))
+                (record_field_expr
+                  (field_name)
+                  (expr_body
+                    (tag_expr
+                      (tag)))))))
+          (value_declaration
+            (decl_left
+              (identifier_pattern
+                (identifier)))
+            (expr_body
+              (function_call_expr
+                (variable_expr
+                  (module)
+                  (identifier))
+                (variable_expr
+                  (identifier))
+                (variable_expr
+                  (identifier))
+                (anon_fun_expr
+                  (lambda_delimiter)
+                  (argument_patterns
+                    (record_pattern
+                      (record_field_pattern
+                        (field_name))
+                      (record_field_pattern
+                        (field_name)))
+                    (identifier_pattern
+                      (identifier)))
+                  (lambda_delimiter)
+                  (expr_body
+                    (when_is_expr
+                      (when)
+                      (variable_expr
+                        (identifier))
+                      (is)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (const_pattern
+                          (xint))
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name))
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (tag_expr
+                                    (tag))))))))
+                      (line_comment)
+                      (when_is_branch
+                        (wildcard_pattern)
+                        (arrow)
+                        (expr_body
+                          (tag_expr
+                            (tag)
+                            (record_expr
+                              (record_field_expr
+                                (field_name)
+                                (expr_body
+                                  (bin_op_expr
+                                    (variable_expr
+                                      (identifier))
+                                    (operator)
+                                    (const
+                                      (int)))))
+                              (record_field_expr
+                                (field_name))))))))))))
+          (when_is_expr
+            (when)
+            (field_access_expr
+              (variable_expr
+                (identifier))
+              (identifier))
+            (is)
+            (when_is_branch
+              (tag_pattern
+                (tag))
+              (arrow)
+              (expr_body
+                (bin_op_expr
+                  (parenthesized_expr
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (variable_expr
+                          (identifier)))))
+                  (operator)
+                  (const
+                    (int))
+                  (operator)
+                  (variable_expr
+                    (module)
+                    (identifier))
+                  (operator)
+                  (function_call_expr
+                    (variable_expr
+                      (module)
+                      (identifier))
+                    (list_expr
+                      (const
+                        (char))))
+                  (operator)
+                  (function_call_expr
+                    (variable_expr
+                      (module)
+                      (identifier))
+                    (variable_expr
+                      (identifier)))
+                  (operator)
+                  (function_call_expr
+                    (variable_expr
+                      (module)
+                      (identifier))
+                    (list_expr
+                      (const
+                        (char)))))))
+            (when_is_branch
+              (tag_pattern
+                (tag))
+              (arrow)
+              (expr_body
+                (value_declaration
+                  (decl_left
+                    (record_pattern
+                      (record_field_pattern
+                        (field_name)
+                        (identifier_pattern
+                          (identifier)))
+                      (record_field_pattern
+                        (field_name)
+                        (identifier_pattern
+                          (identifier)))))
+                  (expr_body
+                    (function_call_expr
+                      (variable_expr
+                        (module)
+                        (identifier))
+                      (variable_expr
+                        (identifier))
+                      (field_access_expr
+                        (variable_expr
+                          (identifier))
+                        (identifier)))))
+                (line_comment)
+                (line_comment)
+                (value_declaration
+                  (decl_left
+                    (identifier_pattern
+                      (identifier)))
+                  (expr_body
+                    (bin_op_expr
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (variable_expr
+                          (identifier)))
+                      (operator)
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (const
+                          (int)))
+                      (operator)
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (const
+                          (int)))
+                      (operator)
+                      (variable_expr
+                        (module)
+                        (identifier))
+                      (operator)
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (list_expr
+                          (const
+                            (char))))
+                      (operator)
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (variable_expr
+                          (identifier))))))
+                (line_comment)
+                (line_comment)
+                (bin_op_expr
+                  (function_call_expr
+                    (variable_expr
+                      (module)
+                      (identifier))
+                    (variable_expr
+                      (identifier))
+                    (variable_expr
+                      (identifier))
+                    (anon_fun_expr
+                      (lambda_delimiter)
+                      (argument_patterns
+                        (identifier_pattern
+                          (identifier))
+                        (identifier_pattern
+                          (identifier)))
+                      (lambda_delimiter)
+                      (expr_body
+                        (function_call_expr
+                          (variable_expr
+                            (module)
+                            (identifier))
+                          (variable_expr
+                            (identifier))
+                          (parenthesized_expr
+                            (expr_body
+                              (function_call_expr
+                                (variable_expr
+                                  (identifier))
+                                (variable_expr
+                                  (identifier)))))))))
+                  (operator)
+                  (function_call_expr
+                    (variable_expr
+                      (module)
+                      (identifier))
+                    (list_expr
+                      (const
+                        (char)))))))))))))
+
+================================================================================
+complex_patterns
+================================================================================
+start=|bytes|
+    when bytes is
+        ['{',.. as rest]-> record rest (Dict.empty{})
+        []-> todo{}
+        _-> decErr (Start) bytes
+
+record=|bytes,dict|
+    when bytes is
+    ['}',.. as rest]-> decOk (dict) rest
+    ['"',.. as rest]->
+        when field rest  is
+            {result:Ok (name,num),rest:rest2}-> record rest2 (dict|>Dict.insert name num)
+            {result:Err e,rest:rest2}->decErr e rest2
+
+    []-> todo {}
+    _->decErr (Record "couldn't decode record ") bytes
+
+field =|bytes|
+    when fieldName bytes [] is
+        {result: Ok name, rest}->
+            when rest is
+            [':',.. as rest2] ->
+                numRes=number bytes
+                when numRes is
+                    {result:Ok num,rest:rest3}->
+                        decOk (name,num) rest3
+                    {result:Err e,rest:rest3}->decErr e rest3
+            []-> todo{}
+            _-> decErr FieldJoiner bytes
+        _-> decErr Field bytes
+
+decErr=| e,rest | {result:Err (e),rest}
+decOk=| e,rest | {result:Ok(e),rest}
+
+isNumber=| b| b>= '0' && b <= '9'
+
+todo =|a| crash "todo"
+
+number= |bytes|
+    when bytes is
+    [a,.. as rest] if isNumber a-> decOk (30u8-a) rest
+    [_,..]-> decErr (Num "not a number") bytes
+    []->todo{}
+
+fieldName =|bytes,name|
+    when bytes is
+    ['"',.. as rest] -> {result: Ok name,rest}
+    [a,.. as rest]-> fieldName rest (name|>List.append a)
+    []->todo{}
+    _->decErr (FieldName ) bytes
+
+--------------------------------------------------------------------------------
+
+(file
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (when_is_expr
+            (when)
+            (variable_expr
+              (identifier))
+            (is)
+            (when_is_branch
+              (list_pattern
+                (const
+                  (char))
+                (range_pattern
+                  (identifier)))
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (module)
+                          (identifier))
+                        (record_expr)))))))
+            (when_is_branch
+              (list_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (record_expr))))
+            (when_is_branch
+              (wildcard_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (tag_expr
+                        (tag))))
+                  (variable_expr
+                    (identifier))))))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (when_is_expr
+            (when)
+            (variable_expr
+              (identifier))
+            (is)
+            (when_is_branch
+              (list_pattern
+                (const
+                  (char))
+                (range_pattern
+                  (identifier)))
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (variable_expr
+                        (identifier))))
+                  (variable_expr
+                    (identifier)))))
+            (when_is_branch
+              (list_pattern
+                (const
+                  (char))
+                (range_pattern
+                  (identifier)))
+              (arrow)
+              (expr_body
+                (when_is_expr
+                  (when)
+                  (function_call_expr
+                    (variable_expr
+                      (identifier))
+                    (variable_expr
+                      (identifier)))
+                  (is)
+                  (when_is_branch
+                    (record_pattern
+                      (record_field_pattern
+                        (field_name)
+                        (tag_pattern
+                          (tag)
+                          (tuple_pattern
+                            (identifier_pattern
+                              (identifier))
+                            (identifier_pattern
+                              (identifier)))))
+                      (record_field_pattern
+                        (field_name)
+                        (identifier_pattern
+                          (identifier))))
+                    (arrow)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (variable_expr
+                          (identifier))
+                        (parenthesized_expr
+                          (expr_body
+                            (bin_op_expr
+                              (variable_expr
+                                (identifier))
+                              (operator)
+                              (function_call_expr
+                                (variable_expr
+                                  (module)
+                                  (identifier))
+                                (variable_expr
+                                  (identifier))
+                                (variable_expr
+                                  (identifier)))))))))
+                  (when_is_branch
+                    (record_pattern
+                      (record_field_pattern
+                        (field_name)
+                        (tag_pattern
+                          (tag)
+                          (identifier_pattern
+                            (identifier))))
+                      (record_field_pattern
+                        (field_name)
+                        (identifier_pattern
+                          (identifier))))
+                    (arrow)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (variable_expr
+                          (identifier))
+                        (variable_expr
+                          (identifier))))))))
+            (when_is_branch
+              (list_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (record_expr))))
+            (when_is_branch
+              (wildcard_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (const
+                          (string)))))
+                  (variable_expr
+                    (identifier))))))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (when_is_expr
+            (when)
+            (function_call_expr
+              (variable_expr
+                (identifier))
+              (variable_expr
+                (identifier))
+              (list_expr))
+            (is)
+            (when_is_branch
+              (record_pattern
+                (record_field_pattern
+                  (field_name)
+                  (tag_pattern
+                    (tag)
+                    (identifier_pattern
+                      (identifier))))
+                (record_field_pattern
+                  (field_name)))
+              (arrow)
+              (expr_body
+                (when_is_expr
+                  (when)
+                  (variable_expr
+                    (identifier))
+                  (is)
+                  (when_is_branch
+                    (list_pattern
+                      (const
+                        (char))
+                      (range_pattern
+                        (identifier)))
+                    (arrow)
+                    (expr_body
+                      (value_declaration
+                        (decl_left
+                          (identifier_pattern
+                            (identifier)))
+                        (expr_body
+                          (function_call_expr
+                            (variable_expr
+                              (identifier))
+                            (variable_expr
+                              (identifier)))))
+                      (when_is_expr
+                        (when)
+                        (variable_expr
+                          (identifier))
+                        (is)
+                        (when_is_branch
+                          (record_pattern
+                            (record_field_pattern
+                              (field_name)
+                              (tag_pattern
+                                (tag)
+                                (identifier_pattern
+                                  (identifier))))
+                            (record_field_pattern
+                              (field_name)
+                              (identifier_pattern
+                                (identifier))))
+                          (arrow)
+                          (expr_body
+                            (function_call_expr
+                              (variable_expr
+                                (identifier))
+                              (tuple_expr
+                                (variable_expr
+                                  (identifier))
+                                (variable_expr
+                                  (identifier)))
+                              (variable_expr
+                                (identifier)))))
+                        (when_is_branch
+                          (record_pattern
+                            (record_field_pattern
+                              (field_name)
+                              (tag_pattern
+                                (tag)
+                                (identifier_pattern
+                                  (identifier))))
+                            (record_field_pattern
+                              (field_name)
+                              (identifier_pattern
+                                (identifier))))
+                          (arrow)
+                          (expr_body
+                            (function_call_expr
+                              (variable_expr
+                                (identifier))
+                              (variable_expr
+                                (identifier))
+                              (variable_expr
+                                (identifier))))))))
+                  (when_is_branch
+                    (list_pattern)
+                    (arrow)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (record_expr))))
+                  (when_is_branch
+                    (wildcard_pattern)
+                    (arrow)
+                    (expr_body
+                      (function_call_expr
+                        (variable_expr
+                          (identifier))
+                        (tag_expr
+                          (tag))
+                        (variable_expr
+                          (identifier))))))))
+            (when_is_branch
+              (wildcard_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (tag_expr
+                    (tag))
+                  (variable_expr
+                    (identifier))))))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (record_expr
+            (record_field_expr
+              (field_name)
+              (expr_body
+                (tag_expr
+                  (tag)
+                  (parenthesized_expr
+                    (expr_body
+                      (variable_expr
+                        (identifier)))))))
+            (record_field_expr
+              (field_name)))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (record_expr
+            (record_field_expr
+              (field_name)
+              (expr_body
+                (tag_expr
+                  (tag)
+                  (parenthesized_expr
+                    (expr_body
+                      (variable_expr
+                        (identifier)))))))
+            (record_field_expr
+              (field_name)))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (bin_op_expr
+            (variable_expr
+              (identifier))
+            (operator)
+            (const
+              (char))
+            (operator)
+            (variable_expr
+              (identifier))
+            (operator)
+            (const
+              (char)))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (function_call_expr
+            (variable_expr
+              (identifier))
+            (const
+              (string)))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (when_is_expr
+            (when)
+            (variable_expr
+              (identifier))
+            (is)
+            (when_is_branch
+              (list_pattern
+                (identifier_pattern
+                  (identifier))
+                (range_pattern
+                  (identifier)))
+              (if
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (variable_expr
+                    (identifier))))
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (bin_op_expr
+                        (const
+                          (uint))
+                        (operator)
+                        (variable_expr
+                          (identifier)))))
+                  (variable_expr
+                    (identifier)))))
+            (when_is_branch
+              (list_pattern
+                (wildcard_pattern)
+                (range_pattern))
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (const
+                          (string)))))
+                  (variable_expr
+                    (identifier)))))
+            (when_is_branch
+              (list_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (record_expr)))))))))
+  (value_declaration
+    (decl_left
+      (identifier_pattern
+        (identifier)))
+    (expr_body
+      (anon_fun_expr
+        (lambda_delimiter)
+        (argument_patterns
+          (identifier_pattern
+            (identifier))
+          (identifier_pattern
+            (identifier)))
+        (lambda_delimiter)
+        (expr_body
+          (when_is_expr
+            (when)
+            (variable_expr
+              (identifier))
+            (is)
+            (when_is_branch
+              (list_pattern
+                (const
+                  (char))
+                (range_pattern
+                  (identifier)))
+              (arrow)
+              (expr_body
+                (record_expr
+                  (record_field_expr
+                    (field_name)
+                    (expr_body
+                      (tag_expr
+                        (tag)
+                        (variable_expr
+                          (identifier)))))
+                  (record_field_expr
+                    (field_name)))))
+            (when_is_branch
+              (list_pattern
+                (identifier_pattern
+                  (identifier))
+                (range_pattern
+                  (identifier)))
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (bin_op_expr
+                        (variable_expr
+                          (identifier))
+                        (operator)
+                        (function_call_expr
+                          (variable_expr
+                            (module)
+                            (identifier))
+                          (variable_expr
+                            (identifier)))))))))
+            (when_is_branch
+              (list_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (record_expr))))
+            (when_is_branch
+              (wildcard_pattern)
+              (arrow)
+              (expr_body
+                (function_call_expr
+                  (variable_expr
+                    (identifier))
+                  (parenthesized_expr
+                    (expr_body
+                      (tag_expr
+                        (tag))))
+                  (variable_expr
+                    (identifier)))))))))))


### PR DESCRIPTION
This update supports parsing the new lambda syntax `|args| expr` syntax in addition to the old `\args -> expr` syntax:

https://github.com/roc-lang/roc/pull/7518